### PR TITLE
Muflik/fix find one

### DIFF
--- a/src/main/java/com/compliment/server/service/ComplimentServiceImpl.java
+++ b/src/main/java/com/compliment/server/service/ComplimentServiceImpl.java
@@ -22,7 +22,8 @@ public List<Compliment> getAll() {
 
 @Override
 public Compliment getByID(Long id) {
-        return repository.findOne(id);
+        repository.findById(id);
+        return repository.getOne(id);
         }
 
 @Override

--- a/src/main/java/com/compliment/server/service/ComplimentServiceImpl.java
+++ b/src/main/java/com/compliment/server/service/ComplimentServiceImpl.java
@@ -22,7 +22,7 @@ public List<Compliment> getAll() {
 
 @Override
 public Compliment getByID(Long id) {
-        repository.findById(id);
+//        repository.findById(id);
         return repository.getOne(id);
         }
 


### PR DESCRIPTION
Зачем тут: findOne() ? Для этого метода нужно пример предоставить.
<S extends T> Optional<S> findOne(Example<S> var1);

смотри доку: ExampleMatcher - 5.6.2. Usage
https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#query-by-example.matchers

Тут надо:
 repository.findById(id);
 repository.getOne(id);






